### PR TITLE
Rewrite dockerfile to ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY --chown=1000:1000 . .
 RUN make build
 
 
-FROM ubuntu:focal
+FROM ubuntu:focal-20220426
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	keepalived && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,17 @@
-ARG GOVERSION=1.15
+ARG GOVERSION=1.18.1-202204291412
 
-FROM golang:${GOVERSION}-alpine as builder
+FROM nexus.adsrv.wtf/click/golang:${GOVERSION} as builder
 
 WORKDIR /build
-
-RUN apk add --no-cache make git bash
-
-ADD . .
-
+COPY --chown=1000:1000 . .
 RUN make build
 
-FROM alpine:3.12
 
-COPY --from=builder /build/keepalived-exporter . 
+FROM ubuntu:focal
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	keepalived && \
+	apt-get clean && rm -fr /var/cache/apt/ && rm /usr/sbin/keepalived
+COPY --from=builder /build/keepalived-exporter .
 EXPOSE 9165
-
 ENTRYPOINT [ "./keepalived-exporter" ]


### PR DESCRIPTION
Стандартный докер образ не рассчитан на такое применение когда keepalived на хосте, а экспортер в докере, пришлось немного докостылять. Идея в том чтобы поставить в образ все зависимости keepalived а сам бинарник удалить и пробрасывать внутрь при запуске (не уверен что это сильно надо, нужно только для корректного определения версии, но на всякий случай пусть будет такая защита)

Запускаться будет примерно так:
docker run --rm -it -v /usr/sbin/keepalived:/usr/sbin/keepalived -v /tmp:/tmp -v /var/run:/var/run --pid=host --net=host --security-opt apparmor=unconfined --cap-drop=ALL --cap-add=KILL nexus.adsrv.wtf/click/keepalived-exporter:1.2